### PR TITLE
Update URL and label of payment

### DIFF
--- a/mailing/templates/factura-digital.html
+++ b/mailing/templates/factura-digital.html
@@ -110,7 +110,7 @@
                                             href="https://www.prontopago.com.ar/" target="_new">PRONTO PAGO</a>
                                             |
                                         <a style="text-decoration: none; color: #000000; cursor: pointer;"
-                                            href="https://www.eternet.com.ar/quiero-pagar" target="_new">INFORMACION ONLINE</a>
+                                            href="https://www.eternet.com.ar/quiero-pagar" target="_new">SITIO WEB</a>
                                             |
                                         <a style="text-decoration: none; color: #000000; cursor: pointer;"
                                             href="https://www.e-pagofacil.com/#/" target="_new">PAGO FÁCIL</a>

--- a/mailing/templates/factura-digital.html
+++ b/mailing/templates/factura-digital.html
@@ -110,7 +110,7 @@
                                             href="https://www.prontopago.com.ar/" target="_new">PRONTO PAGO</a>
                                             |
                                         <a style="text-decoration: none; color: #000000; cursor: pointer;"
-                                            href="https://www.eternet.cc/EntidadesCobros.aspx" target="_new">ETERNET ON LINE</a>
+                                            href="https://www.eternet.com.ar/quiero-pagar" target="_new">INFORMACION ONLINE</a>
                                             |
                                         <a style="text-decoration: none; color: #000000; cursor: pointer;"
                                             href="https://www.e-pagofacil.com/#/" target="_new">PAGO FÁCIL</a>


### PR DESCRIPTION
Closes https://github.com/Eternet/Devs.Issues/issues/535

Se actualiza una URL deprecada que daba un 404 por la URL "Quiero Pagar"

Este es el proyecto de donde sale el aviso, y el servicio que obtiene ese HTML:
 
https://github.com/Eternet/Eternet.ReportsGenerator/blob/430ce1562934af7edc0774c76ee806f92b68cbb2/src/Eternet.Reports/Eternet.Reports.Api/Services/Cache/GetHtmlBodyMessage.cs
 
El HTML no está guardado en ese proyecto, lo obtiene de una URL pública:
 
https://cdn.eternet.cc/mailing/templates/factura-digital.html
 
El DNS cdn.eternet.cc corresponde a este repositorio de Imagen por eso esta actualizacion aca.
 
Por algun motivo no me deja asignar reviewers @Germandf asi que te etiqueto