### PR TITLE
Corregir URL de LU24 en el CDN

### DIFF
--- a/banner/lu24/codigo-internet-movil-2026.txt
+++ b/banner/lu24/codigo-internet-movil-2026.txt
@@ -1,6 +1,6 @@
 <!-- LU24 — Eternet Internet + Móvil -->
 <a href="https://promos.eternet.com.ar/internet-movil" target="_blank" rel="noopener sponsored" aria-label="Conocé Internet más Móvil de Eternet">
   <video width="500" height="500" autoplay muted loop playsinline preload="metadata" style="display:block;max-width:100%;height:auto;">
-    <source src="https://cdn.eternet.cc/banner/LU24/eternet-internet-movil-lu24.mp4" type="video/mp4">
+    <source src="https://cdn.eternet.cc/banner/lu24/eternet-internet-movil-lu24.mp4" type="video/mp4">
   </video>
 </a>


### PR DESCRIPTION
## Qué corrige

Actualiza el bloque de implementación de LU24 para usar la carpeta real del CDN en minúsculas (`banner/lu24`).

## Motivo

GitHub Pages distingue mayúsculas y minúsculas: la URL con `banner/LU24` devolvía 404, mientras que `banner/lu24` responde correctamente.

## Verificación

- URL en minúsculas: HTTP 200.
- URL en mayúsculas: HTTP 404.
- No modifica el video ni los demás medios.